### PR TITLE
fix: the same description inside nested html should have equal ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ To get this running locally do the following steps:
 
 - publish: npx bazel run :publish
 
----
+## Run tests
 
+- `npm test`
+
+## publish @soxhub/formatjs-cli
+
+- bump version in /cli/package.json
+- run `yarn bazel run //packages/cli:publish`
+
+---
 
 [![Unit Tests](https://github.com/formatjs/formatjs/actions/workflows/tests.yml/badge.svg)](https://github.com/formatjs/formatjs/actions/workflows/tests.yml)
 [![Karma Tests](https://github.com/formatjs/formatjs/actions/workflows/tests-karma.yml/badge.svg)](https://github.com/formatjs/formatjs/actions/workflows/tests-karma.yml)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soxhub/formatjs-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A CLI for formatjs.",
   "keywords": [
     "intl",

--- a/packages/cli/src/hbs_extractor.ts
+++ b/packages/cli/src/hbs_extractor.ts
@@ -3,10 +3,11 @@ import {transform} from 'ember-template-recast'
 function extractText(node: any, fileName: any, options: any) {
   if (node.path.original === 'format-message') {
     let message = node.params[0]?.original
-    let desc = node.params[1]?.original
+    let desc = node.params[1]?.original?.trim().replace(/\s+/gm, ' ')
     let defaultMessage = message?.trim().replace(/\s+/gm, ' ')
-    // overrideIdFn needs to receive defaultMessage with already trimmed whitespaces
+    // overrideIdFn needs to receive defaultMessage/description with already trimmed whitespaces
     // so the resulting id is the same if messages have the same content but have different indentation
+    // id has to be generated the same way in soxhub/ember-formatjs/replace-key-transform !!!!!!!!!!!!!!!!!!!!!!
     let id = options.overrideIdFn(undefined, defaultMessage, desc, fileName)
     options.onMsgExtracted(undefined, {
       id: id,

--- a/packages/cli/tests/unit/__snapshots__/hbs_extractor.test.ts.snap
+++ b/packages/cli/tests/unit/__snapshots__/hbs_extractor.test.ts.snap
@@ -19,13 +19,13 @@ Array [
   },
   Object {
     "defaultMessage": "Very long message with multiple breaklines and multiple spaces '<a' href={href}> Link '</a>'",
-    "description": undefined,
-    "id": "7NZtXw",
+    "description": "Nice description",
+    "id": "gEqtiO",
   },
   Object {
     "defaultMessage": "Very long message with multiple breaklines and multiple spaces '<a' href={href}> Link '</a>'",
-    "description": undefined,
-    "id": "7NZtXw",
+    "description": "Nice description",
+    "id": "gEqtiO",
   },
 ]
 `;

--- a/packages/cli/tests/unit/fixtures/comp.hbs
+++ b/packages/cli/tests/unit/fixtures/comp.hbs
@@ -29,6 +29,7 @@
       multiple breaklines
       and multiple spaces
       '<a' href={href}> Link '</a>'"
+    'Nice description'
     href='/whatever/link'
     htmlSafe=true
   }}
@@ -42,6 +43,8 @@
         multiple breaklines
         and multiple spaces
         '<a' href={href}> Link '</a>'"
+      'Nice
+        description'
       href='/whatever/link'
       htmlSafe=true
     }}


### PR DESCRIPTION
The different indentations and new lines in the description should extract the same id.
**Id is generated based on trimmed message and description and the same logic should be implemented also in soxhub/ember-formatjs/replace-key-transform!!!!!!!!!!!**

```hbs
{{format-message "Default message" "Nice description"}}
```

should extract the same id as the following:

```hbs
{{format-message 
    "Default 
    message" 
    "Nice 
    description"}}
```