### PR TITLE
bugfix: fix clobbered formatjs dependencies

### DIFF
--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.22.10",
-    "@formatjs/icu-messageformat-parser": "workspace:*",
-    "@formatjs/ts-transformer": "workspace:*",
+    "@formatjs/icu-messageformat-parser": "2.6.0",
+    "@formatjs/ts-transformer": "3.13.3",
     "@glimmer/env": "^0.1.7",
     "@glimmer/reference": "^0.84.3",
     "@glimmer/syntax": "^0.84.3",


### PR DESCRIPTION
Fixes a dependency clobbering. Should not be `workspace:*` but actual dependency versions.
https://github.com/soxhub/formatjs/commit/731fe45000dc06d7f930de208c24933678e3b7d5#diff-b1bf3209d720206e128e6592b41acf23a6b804b1d77abd2912b9be3846ead90cL37

Currently results in this error when attempting to install:
![Screenshot 2023-09-20 at 9 32 09 AM](https://github.com/soxhub/formatjs/assets/102083128/c1c920a5-d150-4080-b3cb-ab78ae26faa8)

We will want to cut a new version after this is merged.
