### PR TITLE
bugfix: passing opts to hbs_extractor instead of scriptParseFn for correct options object

### DIFF
--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -150,7 +150,7 @@ async function processFile(
   } else if (fn.endsWith('.hbs')) {
     debug('Processing %s using hbs extractor', fn)
     const {parseFile} = await import('./hbs_extractor')
-    parseFile(source, fn, scriptParseFn)
+    parseFile(source, fn, opts)
   } else if (fn.endsWith('.gts') || fn.endsWith('.gjs')) {
     debug('Processing %s as gts/gjs file', fn)
     const {parseFile} = await import('./gts_extractor')


### PR DESCRIPTION
Due to a bad branch rebase, we were passing the wrong thing to the hbs parseFile call
https://github.com/soxhub/formatjs/commit/731fe45000dc06d7f930de208c24933678e3b7d5#diff-4ea171930d2ad4ddf25aa6c79e01c6228a23b0c3cbf27f61c7bed73e83950748R153

This was resulting in an error when running
```
Error: Command failed with exit code 1: node /home/runner/work/auditboard-frontend/auditboard-frontend/tools/intl-extractor/worker.mjs -f /home/runner/work/auditboard-frontend/auditboard-frontend/tmp/files-list-1.txt -o /home/runner/work/auditboard-frontend/auditboard-frontend/tmp/partial-extract-1.json
/home/runner/work/auditboard-frontend/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.8_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/hbs_extractor.js:13
        let id = options.overrideIdFn(undefined, defaultMessage, desc, fileName);
                         ^

TypeError: options.overrideIdFn is not a function
    at extractText (/home/runner/work/auditboard-frontend/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.8_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/hbs_extractor.js:13:26)
    at MustacheStatement (/home/runner/work/auditboard-frontend/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.8_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/hbs_extractor.js:25:17)
```

This PR fixes it by passing `opts` as expected