### PR TITLE
chore: bumped ember-template-tag@2.3.15 for type fixes

### DIFF
--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -48,7 +48,7 @@
     "chalk": "^4.0.0",
     "commander": "8",
     "ember-template-recast": "^6.1.4",
-    "ember-template-tag": "^2.3.14",
+    "ember-template-tag": "^2.3.15",
     "fast-glob": "^3.2.7",
     "fs-extra": "10",
     "json-stable-stringify": "^1.0.1",

--- a/packages/cli-lib/tests/unit/__snapshots__/gts_extractor.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/gts_extractor.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`gts_extractor 1`] = `
 [
   {
+    "defaultMessage": "in gjs file",
+    "id": "YCDlzq",
+  },
+  {
     "defaultMessage": "in template",
     "description": "in template desc",
     "id": "7MCO2v",

--- a/packages/cli-lib/tests/unit/fixtures/comp.gjs
+++ b/packages/cli-lib/tests/unit/fixtures/comp.gjs
@@ -8,7 +8,7 @@ export default class Comp extends Component {
 
   get message() {
       return this.intl.formatMessage({
-          defualtMessage: 'in gjs file'
+          defaultMessage: 'in gjs file'
       });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,10 +418,10 @@ importers:
         specifier: ^7.22.10
         version: 7.22.14
       '@formatjs/icu-messageformat-parser':
-        specifier: workspace:*
+        specifier: 2.6.0
         version: link:../icu-messageformat-parser
       '@formatjs/ts-transformer':
-        specifier: workspace:*
+        specifier: 3.13.3
         version: link:../ts-transformer
       '@glimmer/env':
         specifier: ^0.1.7
@@ -457,8 +457,8 @@ importers:
         specifier: ^6.1.4
         version: 6.1.4
       ember-template-tag:
-        specifier: ^2.3.14
-        version: 2.3.14
+        specifier: ^2.3.15
+        version: 2.3.15
       fast-glob:
         specifier: ^3.2.7
         version: 3.2.11
@@ -1225,14 +1225,14 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.22.15
+      '@babel/generator': 7.23.0
       '@babel/helper-compilation-targets': 7.18.9(@babel/core@7.18.10)
       '@babel/helper-module-transforms': 7.18.9
       '@babel/helpers': 7.18.9
       '@babel/parser': 7.22.14
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -1284,10 +1284,11 @@ packages:
     resolution: {integrity: sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.22.15:
     resolution: {integrity: sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==}
@@ -1297,12 +1298,22 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.23.0:
+    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
 
   /@babel/helper-annotate-as-pure@7.16.7:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-annotate-as-pure@7.18.6:
@@ -1317,7 +1328,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.18.9:
@@ -1373,8 +1384,8 @@ packages:
     dependencies:
       '@babel/core': 7.18.5
       '@babel/helper-annotate-as-pure': 7.16.7
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/helper-replace-supers': 7.18.2
@@ -1443,7 +1454,7 @@ packages:
       '@babel/helper-compilation-targets': 7.18.9(@babel/core@7.18.5)
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.18.9
-      '@babel/traverse': 7.22.15
+      '@babel/traverse': 7.23.0
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
@@ -1476,15 +1487,20 @@ packages:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-environment-visitor@7.22.20:
+    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-environment-visitor@7.22.5:
     resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-explode-assignable-expression@7.16.7:
     resolution: {integrity: sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-explode-assignable-expression@7.18.6:
@@ -1505,8 +1521,16 @@ packages:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.15
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.0
+    dev: true
+
+  /@babel/helper-function-name@7.23.0:
+    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-hoist-variables@7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
@@ -1518,13 +1542,13 @@ packages:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-member-expression-to-functions@7.17.7:
     resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.18.9:
@@ -1538,14 +1562,14 @@ packages:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-module-transforms@7.18.0:
     resolution: {integrity: sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==}
@@ -1566,14 +1590,14 @@ packages:
     resolution: {integrity: sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.18.6
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.15
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1581,7 +1605,7 @@ packages:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
@@ -1609,7 +1633,7 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-wrap-function': 7.16.8
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1633,11 +1657,11 @@ packages:
     resolution: {integrity: sha512-XzAIyxx+vFnrOxiQrToSUOzUOn0e1J2Li40ntddek1Y69AXUTXoDJ40/D5RdjFu7s7qHiaeoTiempZcbuVXh2Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1659,13 +1683,13 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-skip-transparent-expression-wrappers@7.16.0:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.18.9:
@@ -1685,13 +1709,13 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
@@ -1707,6 +1731,10 @@ packages:
 
   /@babel/helper-validator-identifier@7.22.15:
     resolution: {integrity: sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.22.5:
@@ -1727,10 +1755,10 @@ packages:
     resolution: {integrity: sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.22.5
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/helper-function-name': 7.23.0
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1761,9 +1789,9 @@ packages:
     resolution: {integrity: sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1771,7 +1799,7 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -1779,7 +1807,7 @@ packages:
     resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -1795,7 +1823,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/parser@7.22.14:
@@ -1811,6 +1839,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.15
+    dev: true
+
+  /@babel/parser@7.23.0:
+    resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.0
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.17.12(@babel/core@7.18.5):
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
@@ -3745,8 +3781,16 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/parser': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+
+  /@babel/template@7.22.15:
+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -3755,6 +3799,7 @@ packages:
       '@babel/code-frame': 7.22.13
       '@babel/parser': 7.22.15
       '@babel/types': 7.22.15
+    dev: true
 
   /@babel/traverse@7.18.11:
     resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
@@ -3796,13 +3841,30 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.22.15
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/generator': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/traverse@7.23.0:
+    resolution: {integrity: sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -3820,7 +3882,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -3837,7 +3899,15 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.23.0:
+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
   /@bazel/bazelisk@1.12.0:
@@ -6476,7 +6546,7 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.15
+      '@babel/types': 7.23.0
 
   /@types/babel__helper-plugin-utils@7.10.0:
     resolution: {integrity: sha512-60YtHzhQ9HAkToHVV+TB4VLzBn9lrfgrsOjiJMtbv/c1jPdekBxaByd6DMsGBzROXWoIL6U3lEFvvbu69RkUoA==}
@@ -6486,8 +6556,8 @@ packages:
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
 
   /@types/babel__traverse@7.17.1:
     resolution: {integrity: sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==}
@@ -7011,8 +7081,8 @@ packages:
   /@vue/compiler-core@3.2.37:
     resolution: {integrity: sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==}
     dependencies:
-      '@babel/parser': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
       '@vue/shared': 3.2.37
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -7067,8 +7137,8 @@ packages:
   /@vue/reactivity-transform@3.2.45:
     resolution: {integrity: sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==}
     dependencies:
-      '@babel/parser': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
       '@vue/compiler-core': 3.2.45
       '@vue/shared': 3.2.45
       estree-walker: 2.0.2
@@ -7862,8 +7932,8 @@ packages:
     resolution: {integrity: sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.15
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.0
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.17.1
 
@@ -10069,6 +10139,18 @@ packages:
       '@glimmer/syntax': 0.84.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /ember-template-tag@2.3.15:
+    resolution: {integrity: sha512-uvFt+eIE4788Yr3X1wYLrh+PYYmasmREh2IoShIrZvOW2dOfC+elSZeqeEacNhbKJUX3tT9XUKlbpYFVwvSvyA==}
+    dependencies:
+      '@babel/generator': 7.23.0
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
+      '@glimmer/syntax': 0.84.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -12262,7 +12344,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/parser': 7.22.15
+      '@babel/parser': 7.23.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -12636,11 +12718,11 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/generator': 7.22.15
+      '@babel/generator': 7.23.0
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.18.10)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.18.10)
-      '@babel/traverse': 7.22.15
-      '@babel/types': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
       '@jest/expect-utils': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0


### PR DESCRIPTION
Brings in some typescript fixes from [`ember-template-tag@2.3.15`](https://github.com/patricklx/ember-template-tag/commit/a4671675ec1218f596fc80d7356e15f6b8d88ec5) to fix an error that occurs when processing gjs/gts files in the client app:

```
file:///Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/execa@7.2.0/node_modules/execa/lib/error.js:60
		error = new Error(message);
		        ^

Error: Command failed with exit code 1: node /Users/jbixby/Dev/soxhub/auditboard-frontend/tools/intl-extractor/worker.mjs -f /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/files-list-13.txt -o /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/partial-extract-13.json
/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:104
      throw new Error(`You gave us a visitor for the node type ${nodeType} but it's not a valid type`);
            ^

Error: You gave us a visitor for the node type EmberTemplate but it's not a valid type
    at verify (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:104:13)
    at Object.explode (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:38:3)
    at traverse (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/index.js:51:12)
    at doTransform (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/ember-template-tag@2.3.14/node_modules/ember-template-tag/dist/commonjs/transform-embedded-templates.js:209:28)
    at transform (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/ember-template-tag@2.3.14/node_modules/ember-template-tag/dist/commonjs/transform-embedded-templates.js:179:29)
    at parseFile (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/gts_extractor.js:10:78)
    at processFile (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:75:9)
    at async Promise.all (index 6)
    at async extract (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:108:22)
    at async Object.extractAndWrite (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:180:31)

Node.js v18.17.1
    at makeError (file:///Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/execa@7.2.0/node_modules/execa/lib/error.js:60:11)
    at handlePromise (file:///Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/execa@7.2.0/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  shortMessage: 'Command failed with exit code 1: node /Users/jbixby/Dev/soxhub/auditboard-frontend/tools/intl-extractor/worker.mjs -f /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/files-list-13.txt -o /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/partial-extract-13.json',
  command: 'node /Users/jbixby/Dev/soxhub/auditboard-frontend/tools/intl-extractor/worker.mjs -f /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/files-list-13.txt -o /Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/partial-extract-13.json',
  escapedCommand: 'node "/Users/jbixby/Dev/soxhub/auditboard-frontend/tools/intl-extractor/worker.mjs" -f "/Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/files-list-13.txt" -o "/Users/jbixby/Dev/soxhub/auditboard-frontend/tmp/partial-extract-13.json"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: '',
  stderr: '/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:104\n' +
    "      throw new Error(`You gave us a visitor for the node type ${nodeType} but it's not a valid type`);\n" +
    '            ^\n' +
    '\n' +
    "Error: You gave us a visitor for the node type EmberTemplate but it's not a valid type\n" +
    '    at verify (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:104:13)\n' +
    '    at Object.explode (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/visitors.js:38:3)\n' +
    '    at traverse (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@babel+traverse@7.22.15/node_modules/@babel/traverse/lib/index.js:51:12)\n' +
    '    at doTransform (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/ember-template-tag@2.3.14/node_modules/ember-template-tag/dist/commonjs/transform-embedded-templates.js:209:28)\n' +
    '    at transform (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/ember-template-tag@2.3.14/node_modules/ember-template-tag/dist/commonjs/transform-embedded-templates.js:179:29)\n' +
    '    at parseFile (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/gts_extractor.js:10:78)\n' +
    '    at processFile (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:75:9)\n' +
    '    at async Promise.all (index 6)\n' +
    '    at async extract (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:108:22)\n' +
    '    at async Object.extractAndWrite (/Users/jbixby/Dev/soxhub/auditboard-frontend/node_modules/.pnpm/@soxhub+formatjs-cli-lib@6.1.9_@vue+compiler-core@3.3.4_@vue+compiler-sfc@3.3.4/node_modules/@soxhub/formatjs-cli-lib/src/extract.js:180:31)\n' +
    '\n' +
    'Node.js v18.17.1',
  cwd: '/Users/jbixby/Dev/soxhub/auditboard-frontend/apps/client',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
```
Fairly certain [this change fixes the issue](https://github.com/patricklx/ember-template-tag/commit/a4671675ec1218f596fc80d7356e15f6b8d88ec5#diff-50ecf83f23aaccafa57e0742db76db2c77ef701d624df5dd38a542372865cf9fR140)
tested locally, and it appears to fix the issue, but am not 100% positive that it's the actual source of the seen error.